### PR TITLE
Add EF migration bootstrap service

### DIFF
--- a/Backend/IMINBackend.Contracts/Services/IAppBootstrapService.cs
+++ b/Backend/IMINBackend.Contracts/Services/IAppBootstrapService.cs
@@ -1,0 +1,12 @@
+﻿namespace IMINBackend.Contracts.Services;
+
+/// <summary>
+/// Service for bootstrap
+/// </summary>
+public interface IAppBootstrapService
+{
+    /// <summary>
+    /// Do the bootstrap protocol
+    /// </summary>
+    Task DoAsync();
+}

--- a/Backend/IMINBackend.Services/Services/Bootstrap/DbBootstrapService.cs
+++ b/Backend/IMINBackend.Services/Services/Bootstrap/DbBootstrapService.cs
@@ -1,0 +1,42 @@
+﻿using IMINBackend.Contracts.Services;
+using IMINBackend.Services.Repositories.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMINBackend.Services.Services.Bootstrap;
+
+/// <summary>
+/// Service to bootstrap the <see cref="IminDbContext"/>
+/// </summary>
+public class DbBootstrapService(IminDbContext context) : IAppBootstrapService
+{
+
+    /// <inheritdoc/>
+    public async Task DoAsync() => await ApplyEfMigration();
+
+    /// <summary>
+    /// Apply EF migrations
+    /// </summary>
+    /// <remarks>
+    /// This methods only apply migrations, adding migration is done manually by dev. See EF tool add migration doc
+    /// </remarks>
+    async Task ApplyEfMigration()
+    {
+
+        // TODO : should move to Ilogger
+        Console.WriteLine("Applying EF migrations");
+
+        try
+        {
+            await context.Database.MigrateAsync();
+
+            // TODO : should move to Ilogger
+            Console.WriteLine("EF migrations succesfully applied");
+
+        }
+        catch (Exception ex)
+        {
+            // TODO : should move to Ilogger
+            Console.WriteLine($"An exception has occured during Ef migrations : {ex}");
+        }
+    }
+}

--- a/Backend/IMINBackend.Services/ServicesExtension.cs
+++ b/Backend/IMINBackend.Services/ServicesExtension.cs
@@ -1,5 +1,7 @@
-﻿using IMINBackend.Contracts.Settings;
+﻿using IMINBackend.Contracts.Services;
+using IMINBackend.Contracts.Settings;
 using IMINBackend.Services.Repositories.Context;
+using IMINBackend.Services.Services.Bootstrap;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
@@ -21,24 +23,47 @@ namespace Microsoft.Extensions.DependencyInjection
             services
                 .Configure<PostgresSettings>(configuration.GetSection(PostgresSettings.SectionName))
                 .ConfigureDbContext(configuration)
+                .AddBootstrapServices(configuration)
                 ;
             return services;
         }
 
-        public static IServiceCollection ConfigureDbContext(this IServiceCollection services, IConfiguration configuration)
+        /// <summary>
+        /// Add <see cref="IAppBootstrapService"/>s to the service container
+        /// </summary>
+        /// <remarks>
+        /// This registration must be done right after app builder creation</remarks>
+        static IServiceCollection AddBootstrapServices(this IServiceCollection services, IConfiguration configuration)
         {
-            var postgresSettings = configuration.GetPostgresSettings();
-            services.AddDbContext<IminDbContext>(option => option.UseNpgsql(postgresSettings.GetConnectionString()));
+            services
+                // db bootstrap serice
+                .AddSingleton<IAppBootstrapService, DbBootstrapService>()
+                ;
             return services;
         }
 
+
+        /// <summary>
+        /// Configure <see cref="IminDbContext"/>
+        /// </summary>
+        static IServiceCollection ConfigureDbContext(this IServiceCollection services, IConfiguration configuration)
+        {
+            var postgresSettings = configuration.GetPostgresSettings();
+            services.AddDbContext<IminDbContext>(
+                option => option.UseNpgsql(postgresSettings.GetConnectionString()),
+                contextLifetime: ServiceLifetime.Singleton
+                );
+            return services;
+        }
+
+        /// <summary>
+        /// Get postgres settings from configuration
+        /// </summary>
         static PostgresSettings GetPostgresSettings(this IConfiguration configuration) => configuration.GetSection("Postgres").Get<PostgresSettings>()!;
 
         /// <summary>
         /// Get the connection string from a <see cref="PostgresSettings"/> instance
         /// </summary>
-        /// <param name="settings"></param>
-        /// <returns></returns>
         static string GetConnectionString(this PostgresSettings settings)
         {
             var builder = new NpgsqlConnectionStringBuilder();
@@ -47,6 +72,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (settings.Password != null) builder.Password = settings.Password;
             if (settings.Username != null) builder.Username = settings.Username;
             if (settings.Host != null) builder.Host = settings.Host;
+            builder.Port = 5432;
             if (settings.MinPoolSize != null) builder.MinPoolSize = settings.MinPoolSize ?? 0;
             if (settings.MaxPoolSize != null) builder.MaxPoolSize = settings.MaxPoolSize ?? 0;
             if (settings.CommandTimeout != null) builder.CommandTimeout = settings.CommandTimeout ?? 0;

--- a/Backend/IMINBackend/appsettings.Development.json
+++ b/Backend/IMINBackend/appsettings.Development.json
@@ -4,9 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "__Postgres": {
-    "Username": "postgres",
-    "DbName": "imin_database"
   }
 }

--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -20,9 +20,9 @@ services:
     image: postgres:14.1-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: /run/secrets/postgres_username
-      POSTGRES_PASSWORD: /run/secrets/postgres_password
-      POSTGRES_DB: /run/secrets/postgres_db_name
+      POSTGRES_USER_FILE: /run/secrets/postgres_username
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+      POSTGRES_DB_FILE: /run/secrets/postgres_db_name
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
# Add EF migration bootstrap service

## 1. Objective
- Apply EF migration on app start

## 2. Dev
- Create `IAppBootstrapService` contract to trigger services on app start
- Create a `DbContextBootstrapService` to handle any db bootstrap tasks
  - Create a task to apply EF migrations

### Additional
- fix a bug to provide db connection settings as docker secrets 

**[TESTS]**
- [X] run a migration